### PR TITLE
Use a better way find package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 setup(
@@ -20,7 +20,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 
-    packages=['aspy.yaml'],
+    packages=find_packages(exclude=['tests*']),
     namespace_packages=['aspy'],
     install_requires=[
         'ordereddict',


### PR DESCRIPTION
I always see this error:

```python
$pre-commit              
Traceback (most recent call last):
  File "/Users/dongweiming/pre-commit/venv/bin/pre-commit", line 9, in <module>
    load_entry_point('pre-commit==0.3.3', 'console_scripts', 'pre-commit')()
  File "/Users/dongweiming/pre-commit/venv/lib/python2.7/site-packages/pkg_resources.py", line 353, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/Users/dongweiming/pre-commit/venv/lib/python2.7/site-packages/pkg_resources.py", line 2321, in load_entry_point
    return ep.load()
  File "/Users/dongweiming/pre-commit/venv/lib/python2.7/site-packages/pkg_resources.py", line 2048, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
  File "/Users/dongweiming/pre-commit/venv/lib/python2.7/site-packages/pre_commit-0.3.3-py2.7.egg/pre_commit/main.py", line 9, in <module>
    from pre_commit.commands.autoupdate import autoupdate
  File "/Users/dongweiming/pre-commit/venv/lib/python2.7/site-packages/pre_commit-0.3.3-py2.7.egg/pre_commit/commands/autoupdate.py", line 6, in <module>
    from aspy.yaml import ordered_dump
ImportError: No module named aspy.yaml
```